### PR TITLE
Add User Data Script for JmeterClient Instance

### DIFF
--- a/ballerina_perf_test_cfn.yaml
+++ b/ballerina_perf_test_cfn.yaml
@@ -231,8 +231,8 @@ Resources:
           - - |
               #!/bin/bash -xe
               cd /home/ubuntu
-              sudo apt-get update
-              sudo apt-get install -y openjdk-8-jdk
+              apt-get update
+              apt-get install -y openjdk-8-jdk
               wget https://s3.us-east-2.amazonaws.com/ballerinaperformancetest/performance-ballerina/performance-ballerina-distribution-0.1.0-SNAPSHOT.tar.gz
               wget https://s3.us-east-2.amazonaws.com/ballerinaperformancetest/performance-common/performance-common-distribution-0.1.1-SNAPSHOT.tar.gz
               tar xzf performance-ballerina-distribution-0.1.0-SNAPSHOT.tar.gz

--- a/ballerina_perf_test_cfn.yaml
+++ b/ballerina_perf_test_cfn.yaml
@@ -225,99 +225,73 @@ Resources:
           DeviceIndex: '0'
           DeleteOnTermination: 'true'
           SubnetId: !Ref Subnet
-      UserData: !Base64
-        'Fn::Join':
-          - ''
-          - - |
-              #!/bin/bash -xe
-              cd /home/ubuntu
-              apt-get update
-              apt-get install -y openjdk-8-jdk
-              wget https://s3.us-east-2.amazonaws.com/ballerinaperformancetest/performance-ballerina/performance-ballerina-distribution-0.1.0-SNAPSHOT.tar.gz
-              wget https://s3.us-east-2.amazonaws.com/ballerinaperformancetest/performance-common/performance-common-distribution-0.1.1-SNAPSHOT.tar.gz
-              tar xzf performance-ballerina-distribution-0.1.0-SNAPSHOT.tar.gz
-              tar xzf performance-common-distribution-0.1.1-SNAPSHOT.tar.gz
-              cd jmeter
-              sudo wget --no-check-certificate --no-proxy 'http://www-us.apache.org/dist//jmeter/binaries/apache-jmeter-4.0.tgz'
-              ./install-jmeter.sh apache-jmeter-4.0.tgz /tmp bzm-http2 websocket-samplers
-              sudo wget --no-check-certificate --no-proxy 'http://search.maven.org/remotecontent?filepath=org/mortbay/jetty/alpn/alpn-boot/8.1.12.v20180117/alpn-boot-8.1.12.v20180117.jar'
-              cd /tmp/apache-jmeter-4.0/bin
-        #    - |
-        #      apt update
-        #    - |
-        #      pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-        #    - ln -s /root/aws-cfn-bootstrap-latest/init/ubuntu/cfn-hup /etc/init.d/cfn-hup
-        #    - '/opt/aws/bin/cfn-init -v '
-        #    - '         --stack '
-        #    - !Ref 'AWS::StackName'
-        #    - '         --resource JMeterClientInstance '
-        #    - '         --region '
-        #    - !Ref 'AWS::Region'
-        #    - |+
-        #
-        #    - '/opt/aws/bin/cfn-signal -e $? '
-        #    - '         --stack '
-        #    - !Ref 'AWS::StackName'
-        #    - '         --resource JMeterClientInstance '
-        #    - '         --region '
-        #    - !Ref 'AWS::Region'
-        #    - |+
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          sudo apt-get -y install python-setuptools
+          mkdir aws-cfn-bootstrap-latest
+          curl https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz | tar xz -C aws-cfn-bootstrap-latest --strip-components 1
+          sudo easy_install aws-cfn-bootstrap-latest
+          cd /home/ubuntu
+          apt-get update
+          apt-get install -y openjdk-8-jdk
+          mkdir test66
+          wget https://s3.us-east-2.amazonaws.com/ballerinaperformancetest/performance-ballerina/performance-ballerina-distribution-0.1.0-SNAPSHOT.tar.gz
+          wget https://s3.us-east-2.amazonaws.com/ballerinaperformancetest/performance-common/performance-common-distribution-0.1.1-SNAPSHOT.tar.gz
+          tar xzf performance-ballerina-distribution-0.1.0-SNAPSHOT.tar.gz
+          tar xzf performance-common-distribution-0.1.1-SNAPSHOT.tar.gz
+          cd jmeter
+          sudo wget --no-check-certificate --no-proxy 'http://www-us.apache.org/dist//jmeter/binaries/apache-jmeter-4.0.tgz'
+          ./install-jmeter.sh apache-jmeter-4.0.tgz /tmp bzm-http2 websocket-samplers
+          cd /home/ubuntu
+          sudo wget --no-check-certificate --no-proxy 'http://search.maven.org/remotecontent?filepath=org/mortbay/jetty/alpn/alpn-boot/8.1.12.v20180117/alpn-boot-8.1.12.v20180117.jar'
+          cd /tmp/apache-jmeter-4.0/bin
+          sudo /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource JMeterClientInstance --region ${AWS::Region}
+    CreationPolicy:
+      ResourceSignal:
+        Count: '1'
+        Timeout: PT7M
+  JMeterServer1Instance:
+    Type: 'AWS::EC2::Instance'
+    DependsOn: [AttachGateway]
+    Properties:
+      ImageId: !FindInMap [ AWSRegion2AMI, !Ref "AWS::Region", AMI ]
+      InstanceType: !Ref JMeterServer1InstanceType
+      KeyName: !Ref KeyName
+      Tags:
+        - Key: Name
+          Value: !Join
+              - ':'
+              - - 'JMeter Server 1'
+                - !Ref TestName
+      NetworkInterfaces:
+        - GroupSet:
+            - !Ref InstanceSecurityGroup
+          AssociatePublicIpAddress: 'false'
+          DeviceIndex: '0'
+          DeleteOnTermination: 'true'
+          SubnetId: !Ref Subnet
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          sudo apt-get -y install python-setuptools
+          mkdir aws-cfn-bootstrap-latest
+          curl https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz | tar xz -C aws-cfn-bootstrap-latest --strip-components 1
+          sudo easy_install aws-cfn-bootstrap-latest
+          cd /home/ubuntu
+          apt-get update
+          apt-get install -y openjdk-8-jdk
+          mkdir test66
 
+         #sudo /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource JMeterServer1Instance --region ${AWS::Region}
     #CreationPolicy:
       #ResourceSignal:
-        #Timeout: PT15M
-  # JMeterServer1Instance:
-  #   Type: 'AWS::EC2::Instance'
-  #   DependsOn: AttachGateway
-  #   Properties:
-  #     ImageId: !FindInMap [ AWSRegion2AMI, !Ref "AWS::Region", AMI ]
-  #     InstanceType: !Ref JMeterServer1InstanceType
-  #     KeyName: !Ref KeyName
-  #     Tags:
-  #       - Key: Name
-  #         Value: !Join
-  #           - ':'
-  #           - - 'JMeter Server 1'
-  #             - !Ref TestName
-  #     NetworkInterfaces:
-  #       - GroupSet:
-  #           - !Ref InstanceSecurityGroup
-  #         AssociatePublicIpAddress: 'false'
-  #         DeviceIndex: '0'
-  #         DeleteOnTermination: 'true'
-  #         SubnetId: !Ref Subnet
-  #     UserData: !Base64
-  #       'Fn::Join':
-  #         - ''
-  #         - - |
-  #             #!/bin/bash -xe
-  #           - |
-  #             apt install -y aws-cfn-bootstrap
-  #           - '/opt/aws/bin/cfn-init -v '
-  #           - '         --stack '
-  #           - !Ref 'AWS::StackName'
-  #           - '         --resource JMeterServer1Instance '
-  #           - '         --region '
-  #           - !Ref 'AWS::Region'
-  #           - |+
-
-  #           - '/opt/aws/bin/cfn-signal -e $? '
-  #           - '         --stack '
-  #           - !Ref 'AWS::StackName'
-  #           - '         --resource JMeterServer1Instance '
-  #           - '         --region '
-  #           - !Ref 'AWS::Region'
-  #           - |+
-
-  #   CreationPolicy:
-  #     ResourceSignal:
-  #       Timeout: PT15M
+        #Count: '1'
+        #Timeout: PT7M
 Outputs:
   URL:
-    Value: !Join
-      - ''
-      - - 'http://'
-        - !GetAtt
-          - JMeterClientInstance
-          - PublicIp
     Description: JMeter Client Public IP
+    Value: !Join
+    - ''
+    - -  http://
+      -  !GetAtt JMeterClientInstance.PublicIp

--- a/ballerina_perf_test_cfn.yaml
+++ b/ballerina_perf_test_cfn.yaml
@@ -225,35 +225,47 @@ Resources:
           DeviceIndex: '0'
           DeleteOnTermination: 'true'
           SubnetId: !Ref Subnet
-      UserData: !Base64 
+      UserData: !Base64
         'Fn::Join':
           - ''
           - - |
               #!/bin/bash -xe
-            - |
-              apt update
-            - |
-              pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-            - ln -s /root/aws-cfn-bootstrap-latest/init/ubuntu/cfn-hup /etc/init.d/cfn-hup
-            - '/opt/aws/bin/cfn-init -v '
-            - '         --stack '
-            - !Ref 'AWS::StackName'
-            - '         --resource JMeterClientInstance '
-            - '         --region '
-            - !Ref 'AWS::Region'
-            - |+
+              cd /home/ubuntu
+              sudo apt-get update
+              sudo apt-get install -y openjdk-8-jdk
+              wget https://s3.us-east-2.amazonaws.com/ballerinaperformancetest/performance-ballerina/performance-ballerina-distribution-0.1.0-SNAPSHOT.tar.gz
+              wget https://s3.us-east-2.amazonaws.com/ballerinaperformancetest/performance-common/performance-common-distribution-0.1.1-SNAPSHOT.tar.gz
+              tar xzf performance-ballerina-distribution-0.1.0-SNAPSHOT.tar.gz
+              tar xzf performance-common-distribution-0.1.1-SNAPSHOT.tar.gz
+              cd jmeter
+              sudo wget --no-check-certificate --no-proxy 'http://www-us.apache.org/dist//jmeter/binaries/apache-jmeter-4.0.tgz'
+              ./install-jmeter.sh apache-jmeter-4.0.tgz /tmp bzm-http2 websocket-samplers
+              sudo wget --no-check-certificate --no-proxy 'http://search.maven.org/remotecontent?filepath=org/mortbay/jetty/alpn/alpn-boot/8.1.12.v20180117/alpn-boot-8.1.12.v20180117.jar'
+              cd /tmp/apache-jmeter-4.0/bin
+        #    - |
+        #      apt update
+        #    - |
+        #      pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+        #    - ln -s /root/aws-cfn-bootstrap-latest/init/ubuntu/cfn-hup /etc/init.d/cfn-hup
+        #    - '/opt/aws/bin/cfn-init -v '
+        #    - '         --stack '
+        #    - !Ref 'AWS::StackName'
+        #    - '         --resource JMeterClientInstance '
+        #    - '         --region '
+        #    - !Ref 'AWS::Region'
+        #    - |+
+        #
+        #    - '/opt/aws/bin/cfn-signal -e $? '
+        #    - '         --stack '
+        #    - !Ref 'AWS::StackName'
+        #    - '         --resource JMeterClientInstance '
+        #    - '         --region '
+        #    - !Ref 'AWS::Region'
+        #    - |+
 
-            - '/opt/aws/bin/cfn-signal -e $? '
-            - '         --stack '
-            - !Ref 'AWS::StackName'
-            - '         --resource JMeterClientInstance '
-            - '         --region '
-            - !Ref 'AWS::Region'
-            - |+
-
-    CreationPolicy:
-      ResourceSignal:
-        Timeout: PT15M
+    #CreationPolicy:
+      #ResourceSignal:
+        #Timeout: PT15M
   # JMeterServer1Instance:
   #   Type: 'AWS::EC2::Instance'
   #   DependsOn: AttachGateway
@@ -274,7 +286,7 @@ Resources:
   #         DeviceIndex: '0'
   #         DeleteOnTermination: 'true'
   #         SubnetId: !Ref Subnet
-  #     UserData: !Base64 
+  #     UserData: !Base64
   #       'Fn::Join':
   #         - ''
   #         - - |
@@ -302,10 +314,10 @@ Resources:
   #       Timeout: PT15M
 Outputs:
   URL:
-    Value: !Join 
+    Value: !Join
       - ''
       - - 'http://'
-        - !GetAtt 
+        - !GetAtt
           - JMeterClientInstance
           - PublicIp
     Description: JMeter Client Public IP


### PR DESCRIPTION
Upload "performance-ballerina" and performance-common distributions to the AWS S3 bucket and wget the distribution within the user data script of the cloud formation template.
Install openjdk-8-jdk package using APT. 
Unzip the downloaded performance-ballerina and performance-common distributions within the instance
Download apache jmeter latest .tar 
Install jmeter by specifying the http2, websocket plugins and jmeter .tar downloaded folder location as arguments to the script
Download ALPN boot jar compatible with latest jdk 

